### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "author": "Thomas Watson Steen <w@tson.dk>",
   "license": "MIT",
   "dependencies": {
-    "abstract-leveldown": "^2.1.0",
+    "abstract-leveldown": "^2.6.0",
     "after-all": "^2.0.0",
-    "mongojs": "^0.18.1"
+    "mongojs": "^2.4.0"
   },
   "devDependencies": {
     "tap": "^0.5.0"


### PR DESCRIPTION
Why?

Because early versions of mongojs package has many legacy dependencies which have to be installed with third-party tools like python (e.g. nan package - http://npm.anvaka.com/#/view/2d/mongojs/1.0.0)

With new versions is much more easy to install the package without extra system dependencies.

let me know if you want me to downgrade deps a little bit.