### PR TITLE
feat: add "extraFields" option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [4, 5, 6, 8, 10, 12, 14]
+        node-version: [10, 12, 14]
         mongodb-version:
           ["2.6", "3.0", "3.2", "3.4", "3.6", "4.0", "4.2", "4.4", "5.0"]
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ db.readStream()
   .on('close', function () { console.log('Show\'s over folks!') })
 ```
 
+Will add `timestamp` key to mongo document on `put`:
+```
+var db = levelup(mongodown('localhost/my-database'), {
+  extraFields: {
+    timestamp: function (k,v) { return Date.now() }
+  }
+})
+```
+
 ## Limitations
 
 MongoDOWN does not support iterator snapshots

--- a/package-lock.json
+++ b/package-lock.json
@@ -351,6 +351,12 @@
         "which": "^1.2.9"
       }
     },
+    "cuid": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/cuid/-/cuid-2.1.8.tgz",
+      "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==",
+      "dev": true
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -384,6 +390,26 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "deferred-leveldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "~2.6.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+          "dev": true,
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        }
+      }
+    },
     "denque": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
@@ -409,6 +435,15 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -664,6 +699,82 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
+    "level-codec": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
+      "dev": true
+    },
+    "level-errors": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "dev": true,
+      "requires": {
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha512-1qua0RHNtr4nrZBgYlpV0qHHeHpcRRWTxEZJ8xsemoHAXNL5tbooh4tPEEqIqsbWCAJBmUmkwYK/sW5OrFjWWw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "level-errors": "^1.0.3",
+        "readable-stream": "^1.0.33",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "levelup": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "dev": true,
+      "requires": {
+        "deferred-leveldown": "~1.2.1",
+        "level-codec": "~7.0.0",
+        "level-errors": "~1.0.3",
+        "level-iterator-stream": "~1.3.0",
+        "prr": "~1.0.1",
+        "semver": "~5.4.1",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
+      }
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -965,6 +1076,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "mongojs": "^3.1.0"
   },
   "devDependencies": {
+    "cuid": "^2.1.8",
+    "levelup": "^1.0.0",
     "tap": "^0.5.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "db"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var cuid = require('cuid')
+var levelup = require('levelup')
+var mongojs = require('mongojs')
 var test = require('tap').test;
 var testCommon = require('./testCommon');
 var MongoDOWN = require('./');
@@ -49,6 +52,82 @@ require('abstract-leveldown/abstract/iterator-test').args(test)
 require('abstract-leveldown/abstract/iterator-test').sequence(test)
 require('abstract-leveldown/abstract/iterator-test').iterator(factory, test, testCommon, testCommon.collectEntries)
 require('abstract-leveldown/abstract/iterator-test').tearDown(test, testCommon)
+
+ test('test "extraFields" put', function (t) {
+   var location = cuid()
+   var now = Date.now()
+   var mongoClient = mongojs(location, ['mongodown'])
+   var db = levelup(location, {
+     db: MongoDOWN,
+     extraFields: {
+       timestamp: function (k, v) {
+         return now
+       }
+     }
+   })
+   db.put('foo', JSON.stringify({ v: 'bar' }), function (err) {
+     t.error(err)
+     mongoClient.mongodown.find(function (err, documents) {
+       t.error(err)
+       t.deepEqual(
+         documents,
+         [{
+           _id: 'foo',
+           value: '{"v":"bar"}',
+           timestamp: now
+         }]
+       )
+       db.get('foo', function (err, record) {
+         t.error(err)
+         t.equal(record, '{"v":"bar"}')
+         mongoClient.dropDatabase(function (err) {
+           mongoClient.close()
+           t.end(err)
+         })
+       })
+     })
+   })
+ })
+
+test('test "extraFields" batch', function (t) {
+  var location = cuid()
+  var now = Date.now()
+  var mongoClient = mongojs(location, ['mongodown'])
+  var db = levelup(location, {
+    db: MongoDOWN,
+    extraFields: {
+      timestamp: function (k, v) {
+        return now
+      }
+    }
+  })
+  db.batch([
+    {type: 'put', key: 'foo', value: 'bar'},
+  ],
+  function (err) {
+    t.error(err)
+    mongoClient.mongodown.find(function (err, documents) {
+      t.error(err)
+      t.deepEqual(
+        documents,
+        [{
+          _id: 'foo',
+          value: 'bar',
+          timestamp: now
+        }]
+      )
+      db.get('foo', function (err, record) {
+        t.error(err)
+        t.equal(record, 'bar')
+        mongoClient.dropDatabase(function (err) {
+          mongoClient.close()
+          t.end(err)
+        })
+      })
+    })
+  })
+})
+
 
 test('end', function (t) {
   t.end();


### PR DESCRIPTION
By default mongodown will store the level value in the "value" property. If you need to save additional data with mongo document then you can do that with "extraFields" option. Extra field value can be derived from key and value of "put" operations.

This will add `timestamp` key  to mongo document on `put`:
```
var db = levelup(mongodown('localhost/my-database'), {
  extraFields: {
    timestamp: function (k,v) { return Date.now() }
  }
})
```
